### PR TITLE
Fix for "Operation not permitted" bug under Cygwin

### DIFF
--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -142,6 +142,9 @@ module Vegas
         false
       rescue Errno::ECONNREFUSED => e
         true
+      rescue Errno::EPERM => e
+        # catches the "Operation not permitted" under Cygwin
+        true
       end
     end
 


### PR DESCRIPTION
Aaron, this is a fix for an error I was getting under Cygwin. When checking to see whether the port is already in use, you expect "Errno::ECONNREFUSED". The thing is, under Cygwin (and maybe even Windows) it raises Errno::EPERM.
