### PR TITLE
Ingnoring proxy

### DIFF
--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -313,6 +313,10 @@ module Vegas
           @options[:port] = port
         }
 
+        opts.on("-x", "--no-proxy", "ingnore env proxy settings (e.g. http_proxy)") { |p|
+          @options[:no_proxy] = true
+        }
+
         opts.on("-e", "--env ENVIRONMENT", "use ENVIRONMENT for defaults (default: development)") { |e|
           @options[:environment] = e
         }

--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -138,7 +138,8 @@ module Vegas
 
     def port_open?(check_url = nil)
       begin
-        open(check_url || url)
+        check_url ||= url
+        options[:no_proxy] ? open(check_url, :proxy => nil) : open(check_url) 
         false
       rescue Errno::ECONNREFUSED => e
         true


### PR DESCRIPTION
Hey, I ran into a situation where when I run this locally, I get a 403 Forbidden due to a proxy on our networks. This is an issue coming from within the open-uri library and it is fixed pretty simply by ignoring any [http|https]_proxy settings in the system env with the :proxy => nil option.

Quick fix, just makes it more accessible to those running inside a network firewall.
