### PR TITLE
No HOME necessary

### DIFF
--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -17,7 +17,7 @@ module Vegas
     attr_reader :app, :app_name, :filesystem_friendly_app_name, :quoted_app_name,
       :rack_handler, :port, :host, :options, :args
 
-    ROOT_DIR   = File.expand_path(File.join('~', '.vegas'))
+    ROOT_DIR = ENV['HOME'] ? File.expand_path(File.join('~', '.vegas')) : nil
     PORT       = 5678
     HOST       = WINDOWS ? 'localhost' : '0.0.0.0'
 
@@ -78,6 +78,9 @@ module Vegas
     end
 
     def app_dir
+      if !options[:app_dir] && !ROOT_DIR
+        raise ArgumentError.new("nor --app-dir neither EVN['HOME'] defined")
+      end
       options[:app_dir] || File.join(ROOT_DIR, filesystem_friendly_app_name)
     end
 

--- a/test/test_vegas_runner.rb
+++ b/test/test_vegas_runner.rb
@@ -2,7 +2,7 @@ require File.join('.', File.dirname(__FILE__), 'test_helper.rb')
 
 Vegas::Runner.class_eval do
   remove_const :ROOT_DIR
-  ROOT_DIR = File.join(File.dirname(__FILE__), 'tmp', '.vegas')
+  Vegas::Runner::ROOT_DIR = File.join(File.dirname(__FILE__), 'tmp', '.vegas')
 end
 
 describe 'Vegas::Runner' do
@@ -157,6 +157,30 @@ describe 'Vegas::Runner' do
       end
     end
 
+    describe 'without environment' do
+
+      Vegas::Runner::ROOT_DIR = nil
+
+      before do
+        @app_dir = './test/tmp'
+      end
+
+      it 'should be ok with --app-dir' do
+        vegas(RackApp1, 'rack_app_1', {:skip_launch => true, :app_dir => @app_dir})
+        @vegas.app_dir.should == @app_dir
+      end
+
+      it 'should raise an exception without --app-dir' do
+        success = false
+        begin
+          vegas(RackApp1, 'rack_app_1', {:skip_launch => true})
+        rescue ArgumentError
+          success = true
+        end
+        success.should == true
+      end
+
+    end
 
   end
 


### PR DESCRIPTION
Hi,

Start fails when there is no HOME env defined (ruby expands '~' as ENV['HOME']).
This can occur when some process start subshells without the parent's env (monit).

The change makes it possible to start when no HOME but --app-dir is defined.

Thanks

--Gilles
