### PR TITLE
Use github url as a gem's homepage

### DIFF
--- a/vegas.gemspec
+++ b/vegas.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     "test/test_vegas_runner.rb",
     "vegas.gemspec"
   ]
-  s.homepage = "http://code.quirkey.com/vegas"
+  s.homepage = "https://github.com/quirkey/vegas"
   s.require_paths = ["lib"]
   s.rubyforge_project = "quirkey"
   s.rubygems_version = "1.8.10"


### PR DESCRIPTION
Hi, I suggest to change the homepage url written at gemspec file.

I think the github project url is useful because of some reasons.
- Developers can find your repo and easy to contribute
- [gem-src](https://rubygems.org/gems/gem-src) integration will be available

Either you can define `homepage_uri` or `soruce_code_uri` at **edit gem links** page at rubygems.org. It also enable to integrate with gem-src.
https://rubygems.org/gems/nyan-cat-formatter/edit (requires login to rubygems.org)
