### PR TITLE
update require for mocha 0.14.0

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 dependencies = %w{
   bacon
-  mocha/standalone
-  mocha/object
+  mocha/api
+  mocha/setup
   sinatra
 }
 


### PR DESCRIPTION
mocha/object is removed from latest mocha and mocha/standalone is deprecated.
