### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ Jeweler::Tasks.new do |s|
   s.email = ["aaron@quirkey.com"]
   s.homepage = %q{http://code.quirkey.com/vegas}
   s.rubyforge_project = %q{quirkey}
+  s.license = %{MIT}
   
   s.add_runtime_dependency(%q<rack>, [">= 1.0.0"])
   

--- a/vegas.gemspec
+++ b/vegas.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
     "vegas.gemspec"
   ]
   s.homepage = "http://code.quirkey.com/vegas"
+  s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "quirkey"
   s.rubygems_version = "1.8.10"


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
