### PR TITLE
rescue OpenURI::HTTPError during port check too

### DIFF
--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -145,7 +145,7 @@ module Vegas
         check_url ||= url
         options[:no_proxy] ? open(check_url, :proxy => nil) : open(check_url)
         false
-      rescue Errno::ECONNREFUSED, Errno::EPERM, Errno::ETIMEDOUT
+      rescue Errno::ECONNREFUSED, Errno::EPERM, Errno::ETIMEDOUT, OpenURI::HTTPError
         true
       end
     end


### PR DESCRIPTION
In restrictive environments you're not allowed to open some urls.
You will face this exception, which now will be rescued.
