### PR TITLE
Add license to gemspec

### DIFF
--- a/vegas.gemspec
+++ b/vegas.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
     "vegas.gemspec"
   ]
   s.homepage = "http://code.quirkey.com/vegas"
+  s.license = "MIT"
   s.require_paths = ["lib"]
   s.rubyforge_project = "quirkey"
   s.rubygems_version = "1.8.10"


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.
