### PR TITLE
Start Travis CI testing environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ test/tmp
 pkg/*
 _layouts
 *.sw?
+/Gemfile.lock
+/.bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: trusty
+sudo: false
+language: ruby
+cache: bundler
+before_install:
+  - gem install bundler
+rvm:
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,16 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'rake', '~> 12.3'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+  gem 'jeweler', '~> 2.3'
+else
+  gem 'jeweler', '~> 2.1'
+end
+# Pin rack as 1.x to pass the unit test temporary.
+# because tests are failed on rack >= 2.
+# rack/showexceptions was renamed to rack/show_exceptions on rack 2.0.0.
+# https://github.com/rack/rack/commit/857641d
+gem 'rack', '< 2'
+gem 'thin', '~> 1.7'


### PR DESCRIPTION
Hello, thank you for maintaining this gem.

I want to add `vegas` to something like modern testing environment with Travis CI.
This PR enables CI tests on Ruby 2.0, 2.1,, and 2.5.

I tested this PR on my repository. You can see the result.
https://travis-ci.org/junaruga/vegas/

You can start Travis CI, enabling your repository's Travis from below page.
https://travis-ci.org/quirkey/vegas

I think that we need additional tasks to improve the testing environment.
But I think it's good as a first testing environment.

The development workflow can be like this.

```
$ ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]

$ bundle -v
Bundler version 1.16.1

$ git clone git@github.com:quirkey/vegas.git

$ cd vegas

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * addressable (2.4.0)
  * bacon (1.1.0)
  * builder (3.2.3)
  * bundler (1.16.1)
  * daemons (1.2.6)
  * descendants_tracker (0.0.4)
  * eventmachine (1.2.7)
  * faraday (0.9.2)
  * git (1.4.0)
  * github_api (0.16.0)
  * hashie (3.5.7)
  * highline (2.0.0)
  * jeweler (2.3.9)
  * jwt (1.5.6)
  * mime-types (2.99.3)
  * mini_portile2 (2.3.0)
  * mocha (0.9.12)
  * multi_json (1.13.1)
  * multi_xml (0.6.0)
  * multipart-post (2.0.0)
  * nokogiri (1.8.2)
  * oauth2 (1.4.0)
  * psych (3.0.2)
  * rack (1.6.10)
  * rake (12.3.1)
  * rdoc (6.0.4)
  * semver2 (3.4.2)
  * sinatra (0.9.6)
  * thin (1.7.2)
  * thread_safe (0.3.6)
  * vegas (0.1.11)

$ bundle exec rake -T
rake build             # Build gem into pkg/
rake clean             # Remove any temporary products
rake clobber           # Remove any generated files
rake console[script]   # Start IRB with all runtime dependencies loaded
rake gemspec           # Generate and validate gemspec
rake gemspec:debug     # Display the gemspec for debugging purposes, as jeweler knows it (not from t...
rake gemspec:generate  # Regenerate the gemspec on the filesystem
rake gemspec:release   # Regenerate and validate gemspec, and then commits and pushes to git
rake gemspec:validate  # Validates the gemspec on the filesystem
rake git:release       # Tag and push release to git
rake install           # Build and install gem using `gem install`
rake release           # Release gem
rake rubygems:release  # Release gem to Gemcutter
rake test              # Run tests
rake version           # Displays the current version

$ bundle exec rake
...
Many warnings
...
26 specifications (26 requirements), 0 failures, 0 errors

$ bundle exec rake gemspec
Generated: vegas.gemspec
vegas.gemspec is valid.

$ git diff
diff --git a/vegas.gemspec b/vegas.gemspec
index a4d0c3c..9821227 100644
--- a/vegas.gemspec
+++ b/vegas.gemspec
@@ -2,21 +2,25 @@
 # DO NOT EDIT THIS FILE DIRECTLY
 # Instead, edit Jeweler::Tasks in Rakefile, and run 'rake gemspec'
 # -*- encoding: utf-8 -*-
+# stub: vegas 0.1.11 ruby lib
...
```

