### PR TITLE
Calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open

### DIFF
--- a/lib/vegas/runner.rb
+++ b/lib/vegas/runner.rb
@@ -143,7 +143,7 @@ module Vegas
     def port_open?(check_url = nil)
       begin
         check_url ||= url
-        options[:no_proxy] ? open(check_url, :proxy => nil) : open(check_url)
+        options[:no_proxy] ? URI.open(check_url, :proxy => nil) : URI.open(check_url)
         false
       rescue Errno::ECONNREFUSED, Errno::EPERM, Errno::ETIMEDOUT
         true


### PR DESCRIPTION
Quick fix to make vegas work in ruby 3.0. Fixes #29